### PR TITLE
add javafx as maven dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>coti-node</artifactId>
     <version>1.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-
     <modules>
         <module>pot</module>
         <module>basenode</module>
@@ -61,6 +60,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
+        <javafx.version>15-ea+1</javafx.version>
     </properties>
+
 
 </project>

--- a/storagenode/pom.xml
+++ b/storagenode/pom.xml
@@ -76,6 +76,11 @@
             <version>2.3</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
     </dependencies>
     <artifactId>storagenode</artifactId>
     <build>

--- a/trustscore/pom.xml
+++ b/trustscore/pom.xml
@@ -11,6 +11,11 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+
     <artifactId>trustscore</artifactId>
     <dependencies>
         <dependency>
@@ -53,6 +58,11 @@
             <artifactId>junit</artifactId>
             <version>4.12</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
I added javafx as a dependency so the build works on newer Java JDKs

I added end of line at the end of the files I edited, it's missing in most of them and it's really important to add this.
I also setup the dependency versions on the main pom.xml under properties, this helps refactors if dependencies need to be updated (which I think is not a bad idea).