### PR TITLE
Add a GitHub Action to build Docker images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,72 @@
+name: Build and push container image
+
+on:
+  push:
+    tags:
+      - '[0-9].[0-9].[0-9]'
+
+env:
+  IMAGE_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  build:
+    if: startsWith(github.ref, 'refs/tags/')
+    name: build and push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=true
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-single-buildx
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MODULE=fullnode
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/create-properties
+++ b/create-properties
@@ -1,0 +1,149 @@
+#!/bin/bash
+# A script to generate a fullnode.properties file from environment variables
+
+set -e pipefail # fail on error , debug all lines
+
+#########################################
+# Preparation
+#########################################
+
+# Set necessary variables from the environment
+
+# Required environment variables:
+#  - ACTION
+#  - SERVERNAME
+#  - PKEY
+#  - SEED
+if [ -z ${ACTION} ]; then
+  echo "Environment variable ACTION not defined"
+  exit 1
+fi
+if [ -z ${SERVERNAME} ]; then
+  echo "Environment variable SERVERNAME not defined"
+  exit 1
+fi
+if [ -z ${PKEY} ]; then
+  echo "Environment variable PKEY not defined"
+  exit 1
+fi
+if [ -z ${SEED} ]; then
+  echo "Environment variable SEED not defined"
+  exit 1
+fi
+
+# Optional environment variables
+# If an environment variable is not found, a default is chosen
+#  - SERVER_PORT
+#  - DATABSE_FOLDER_NAME
+#  - MINIMUM_FEE
+#  - MAXIMUM_FEE
+#  - FEE_PERCENTAGE
+if [ -z ${SERVERPORT} ]; then
+  SERVER_PORT=7070
+fi
+if [ -z ${DATABSE_FOLDER_NAME} ]; then
+  DATABSE_FOLDER_NAME=rocksDB
+fi
+if [ -z ${MINIMUM_FEE} ]; then
+  MINIMUM_FEE=0.01
+fi
+if [ -z ${MAXIMUM_FEE} ]; then
+  MAXIMUM_FEE=25
+fi
+if [ -z ${FEE_PERCENTAGE} ]; then
+  FEE_PERCENTAGE=1
+fi
+
+# Calculate dervied variables 
+SERVER_URL=https://$SERVERNAME
+SERVER_IP=$(curl -s ifconfig.me) 
+echo "Detected Server IP: $SERVERIP"
+LOGGING_FILE_NAME="FullNode1";
+data_dir=/app/data
+mkdir -p $data_dir
+
+#########################################
+# Generate fullnode.properties
+#########################################
+FULLNODE_PROPERTIES_FILE=$data_dir/fullnode.properties
+
+if [[ $ACTION == "testnet" ]];
+then
+cat <<EOF-TESTNET >$FULLNODE_PROPERTIES_FILE
+network=TestNet
+server.ip=$SERVER_IP
+server.port=$SERVER_PORT
+server.url=$SERVER_URL
+application.name=FullNode
+logging.file.name=$LOGGING_FILE_NAME
+database.folder.name=$DATABSE_FOLDER_NAME
+resetDatabase=false
+global.private.key=$PKEY
+fullnode.seed=$SEED
+minimumFee=$MINIMUM_FEE
+maximumFee=$MAXIMUM_FEE
+fee.percentage=$FEE_PERCENTAGE
+zero.fee.user.hashes=9c37d52ae10e6b42d3bb707ca237dd150165daca32bf8ef67f73d1e79ee609a9f88df0d437a5ba5a6cf7c68d63c077fa2c63a21a91fc192dfd9c1fe4b64bb959
+kycserver.public.key=c10052a39b023c8d4a3fc406a74df1742599a387c58bcea2a2093bd85103f3bd22816fa45bbfb26c1f88a112f0c0b007755eb1be1fad3b45f153adbac4752638
+kycserver.url=https://cca.coti.io
+node.manager.ip=52.59.142.53
+node.manager.port=7090
+node.manager.propagation.port=10001
+allow.transaction.monitoring=true
+whitelist.ips=127.0.0.1,0:0:0:0:0:0:0:1
+node.manager.public.key=2fc59886c372808952766fa5a39d33d891af69c354e6a5934a258871407536d6705693099f076226ee5bf4b200422e56635a7f3ba86df636757e0ae42415f7c2
+allow.transaction.monitoring=true
+regular.token.fullnode.fee=1
+EOF-TESTNET
+elif [[ $ACTION == "mainnet" ]];
+then
+cat <<EOF-MAINNET >$FULLNODE_PROPERTIES_FILE
+network=MainNet
+server.ip=$SERVERIP
+server.port=$SERVER_PORT
+server.url=$SERVERURL
+application.name=FullNode
+logging.file.name=$logging_file_name
+database.folder.name=$DATABSE_FOLDER_NAME
+global.private.key=$PKEY
+fullnode.seed=$SEED
+minimumFee=$MINIMUM_FEE
+maximumFee=$MAXIMUM_FEE
+fee.percentage=$FEE_PERCENTAGE
+zero.fee.user.hashes=
+kycserver.public.key=c10052a39b023c8d4a3fc406a74df1742599a387c58bcea2a2093bd85103f3bd22816fa45bbfb26c1f88a112f0c0b007755eb1be1fad3b45f153adbac4752638
+kycserver.url=https://cca.coti.io
+node.manager.ip=35.157.47.86
+node.manager.port=7090
+node.manager.propagation.port=10001
+node.manager.public.key=2fc59886c372808952766fa5a39d33d891af69c354e6a5934a258871407536d6705693099f076226ee5bf4b200422e56635a7f3ba86df636757e0ae42415f7c2
+allow.transaction.monitoring=true
+regular.token.fullnode.fee=1
+EOF-MAINNET
+fi
+
+chown root:root $FULLNODE_PROPERTIES_FILE
+chgrp root $FULLNODE_PROPERTIES_FILE
+
+echo fullnode.properties file successfully generated at $FULLNODE_PROPERTIES_FILE
+
+#########################################
+# Download Clusterstamp
+#########################################
+
+CLUSTERSTAMP_FILE=/app/FullNode1_clusterstamp.csv
+if [ -f "$CLUSTERSTAMP_FILE" ]; then
+  echo "Clusterstamp $CLUSTERSTAMP_FILE exists."
+else
+  if [[ $ACTION == "testnet" ]]; then
+    CLUSTERSTAMP_URL=https://www.dropbox.com/s/rpyercs56zmay0z/FullNode1_clusterstamp.csv
+  elif [[ $ACTION == "mainnet" ]]; then
+    CLUSTERSTAMP_URL=https://coti.tips/downloads/FullNode1_clusterstamp.csv
+  fi
+  echo "Downloading clusterstamp."
+  curl -sL $CLUSTERSTAMP_URL --output $CLUSTERSTAMP_FILE
+  echo "Download completed."
+fi
+
+chown root:root $CLUSTERSTAMP_FILE
+chgrp root $CLUSTERSTAMP_FILE

--- a/create-properties
+++ b/create-properties
@@ -33,12 +33,16 @@ fi
 
 # Optional environment variables
 # If an environment variable is not found, a default is chosen
+#  - SERVER_IP
 #  - SERVER_PORT
 #  - DATABSE_FOLDER_NAME
 #  - MINIMUM_FEE
 #  - MAXIMUM_FEE
 #  - FEE_PERCENTAGE
-if [ -z ${SERVERPORT} ]; then
+if [ -z ${SERVER_IP} ]; then
+  SERVER_IP=$(curl -s ifconfig.me) 
+fi
+if [ -z ${SERVER_PORT} ]; then
   SERVER_PORT=7070
 fi
 if [ -z ${DATABSE_FOLDER_NAME} ]; then
@@ -56,7 +60,6 @@ fi
 
 # Calculate dervied variables 
 SERVER_URL=https://$SERVERNAME
-SERVER_IP=$(curl -s ifconfig.me) 
 echo "Detected Server IP: $SERVER_IP"
 LOGGING_FILE_NAME="FullNode1";
 data_dir=/app/data

--- a/create-properties
+++ b/create-properties
@@ -41,6 +41,7 @@ fi
 #  - FEE_PERCENTAGE
 if [ -z ${SERVER_IP} ]; then
   SERVER_IP=$(curl -s ifconfig.me) 
+  echo "Detected Server IP: $SERVER_IP"
 fi
 if [ -z ${SERVER_PORT} ]; then
   SERVER_PORT=7070
@@ -60,7 +61,6 @@ fi
 
 # Calculate dervied variables 
 SERVER_URL=https://$SERVERNAME
-echo "Detected Server IP: $SERVER_IP"
 LOGGING_FILE_NAME="FullNode1";
 data_dir=/app/data
 mkdir -p $data_dir

--- a/create-properties
+++ b/create-properties
@@ -40,7 +40,7 @@ fi
 #  - MAXIMUM_FEE
 #  - FEE_PERCENTAGE
 if [ -z ${SERVER_IP} ]; then
-  SERVER_IP=$(curl -s ifconfig.me) 
+  SERVER_IP=$(getent ahostsv4 $SERVERNAME | awk '{print $1}' | head -1) 
   echo "Detected Server IP: $SERVER_IP"
 fi
 if [ -z ${SERVER_PORT} ]; then

--- a/create-properties
+++ b/create-properties
@@ -57,7 +57,7 @@ fi
 # Calculate dervied variables 
 SERVER_URL=https://$SERVERNAME
 SERVER_IP=$(curl -s ifconfig.me) 
-echo "Detected Server IP: $SERVERIP"
+echo "Detected Server IP: $SERVER_IP"
 LOGGING_FILE_NAME="FullNode1";
 data_dir=/app/data
 mkdir -p $data_dir


### PR DESCRIPTION
This pull request includes a possible GitHub action (GHA) that automatically builds a Docker container image on each new official release, and pushes the generated image to a container repository. 

The GHA is currently configured to push images to Dockerhub, but can be changed to push to the GitHub container registry (ghcr.io), or any other container registry.

A workflow triggered by the GHA is can be viewed here: https://github.com/tj-wells/coti-node-gha/actions/runs/4133513367

The image created as a result of that workflow can be found here: https://hub.docker.com/r/atomnode/coti-node-gha/tags

To test the image, that image is curretly being used to run my node (testnet.atomnode.tomoswells.com).

I included a script called `create-properties` in the pull request, which uses environment variables to create a `fullnode.properties` file, and downloads the appropriate clusterstamp file. This script is optional, since the `fullnode.properties` and clusterstamp file could in principle be included in the container using volume mounts. On the other hand, I think it’s convenient for node operators if everything needed to run the node can be defined in a single .env file. I’ll leave it up to the Coti team to decide whether to keep the script, or modify it.

I am happy to take any feedback/suggestions for chagnes to any parts of the code.

Thank you.

P.S. Two GitHub actions "secrets" need to be set in the repository settings for the workflow to run succesfully: `DOCKERHUB_USERNAME`, and `​​​​DOCKERHUB_TOKEN`

P.P.S. An example docker-compose.yml file that can be used to run a node using images built with this method can be found here: https://github.com/tomjwells/coti-node